### PR TITLE
Add Summary field to Agentic AI series articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 output
 webroot
 cache
+.cursorrules
+py3/

--- a/content/agentic-ai-en.md
+++ b/content/agentic-ai-en.md
@@ -1,8 +1,20 @@
-Title: From Thinker to Doer — The Paradigm Revolution and Technical Architecture of Agentic AI
+Title: [Agentic AI] From Thinker to Doer — The Paradigm Revolution and Technical Architecture of Agentic AI
 Date: 2024-12-13 14:00
 Category: Computing
 Tags: AI, Agentic, English, Cursor
 Slug: agentic-ai-en
+Summary: Before discussing Agentic AI, I'd like to share two short stories. While chatting with someone online, I wanted to compare Amazon and Google's stock performance over the last five years to support a point I was making. I first searched online for existing comparisons and tools but found nothing. Then I asked ChatGPT if it could help me find or generate a stock price comparison chart. It said it couldn't. By this point, I was ready to give up, as it wasn't worth spending 5 minutes making a chart during a casual conversation. As a last resort, I tried Cursor's latest Agent mode, simply throwing my request at it: generate a chart showing Google and Amazon's stock prices over the last five years, with both stocks aligned at their starting points for easy comparison. To my surprise, Cursor automatically started writing code, installing dependencies, debugging, modifying the program, re-executing, and within a minute gave me exactly the chart I wanted, as shown below. I was truly amazed. It just works.
+
+---
+
+This article is part of the "Understanding and Deploying Agentic AI" series:
+
+* [Agentic AI Series 1: Comparison between Devin and Agent Cursor](/devin-vs-agent-cursor-en.html)
+* Agentic AI Series 2: From Thinker to Doer — The Paradigm Revolution and Technical Architecture of Agentic AI (This Article)
+* [Agentic AI Series 3: Turning &#36;20 into &#36;500 - Transforming Cursor into Devin in One Hour](/cursor-to-devin-en.html)
+* [Agentic AI Series 4: Using Cursor as a Universal Entry Point for AI](/cursor-ai-entry-en.html)
+
+---
 
 ## From "Ask and Answer" to "Ask and Do"
 

--- a/content/agentic-ai.md
+++ b/content/agentic-ai.md
@@ -1,8 +1,21 @@
-Title: 从智者到行者——Agentic AI的范式革命与技术架构
+Title: [Agentic AI] 从智者到行者——Agentic AI的范式革命与技术架构
 Date: 2024-12-13 15:00
 Category: Computing
 Tags: AI, Agentic, Chinese, Cursor
 Slug: agentic-ai
+Math: false
+Summary: 在讨论Agentic AI之前，我想先讲两个小故事。我在网上和别人聊天的时候，想要比较一下亚马逊和谷歌最近五年的股票走势来佐证我的一个观点。我先是上网搜索了有没有现成的比较和工具，发现没有。接着问了ChatGPT，你能不能帮我寻找或者生成一个股价对比图。他说做不到。这时候我已经想着放弃了，因为聊天的过程中，不值当特别花个5分钟去专门做个图出来。最后我死马当活马医，用了Cursor最新的Agent模式，就直接把要求丢给它，让它给我生成一张图，上面有谷歌和亚马逊最近五年的股价，同时把两个股票的起点对齐，这样方便我比较。结果没想到的是，Cursor就开始全自动写程序，装依赖，debug，改程序，重新执行，然后在一分钟之内就给了我想要的图，如下图所示。真是令我大受震撼。It just works。
+
+---
+
+本文是《理解和部署Agentic AI》系列的一部分：
+
+* [Agentic AI系列1：Devin和Agent Cursor使用体验对比](/devin-vs-agent-cursor.html)
+* Agentic AI系列2：从智者到行者——Agentic AI的范式革命与技术架构（本文）
+* [Agentic AI系列3：搏一搏，&#36;20变&#36;500：一小时魔改Cursor变身Devin](/cursor-to-devin.html)
+* [Agentic AI系列4：使用Cursor作为AI的通用入口](/cursor-ai-entry.html)
+
+---
 
 ## 从“我问你答”到“我问你做”
 

--- a/content/cursor-ai-entry-en.md
+++ b/content/cursor-ai-entry-en.md
@@ -1,8 +1,20 @@
-Title: Using Cursor as a Universal Entry Point for AI
+Title: [Agentic AI] Using Cursor as a Universal Entry Point for AI
 Date: 2024-12-19 15:00
 Category: Computing
 Tags: AI, Cursor, English, Agentic
 Slug: cursor-ai-entry-en
+Summary: After completing [the previous article](/cursor-to-devin-en.html) introducing the modifications to Cursor, using Agentic AI in a "I say, you do" mode has become my primary method for leveraging AI. This further inspired me: is it possible to use Cursor or a similar editor as a universal entry point for AI? 
+
+---
+
+This article is part of the "Understanding and Deploying Agentic AI" series:
+
+* [Agentic AI Series 1: Comparison between Devin and Agent Cursor](/devin-vs-agent-cursor-en.html)
+* [Agentic AI Series 2: From Thinker to Doer — The Paradigm Revolution and Technical Architecture of Agentic AI](/agentic-ai-en.html)
+* [Agentic AI Series 3: Turning &#36;20 into &#36;500 - Transforming Cursor into Devin in One Hour](/cursor-to-devin-en.html)
+* Agentic AI Series 4: Using Cursor as a Universal Entry Point for AI (This Article)
+
+---
 
 After completing the [previous article](/cursor-to-devin-en.html) introducing the modifications to Cursor, using Agentic AI in a "I say, you do" mode has become my primary method for leveraging AI. This further inspired me: is it possible to use Cursor or a similar editor as a universal entry point for AI?
 

--- a/content/cursor-ai-entry.md
+++ b/content/cursor-ai-entry.md
@@ -1,8 +1,20 @@
-Title: 使用Cursor作为AI的通用入口
+Title: [Agentic AI] 使用Cursor作为AI的通用入口
 Date: 2024-12-19 15:30
 Category: Computing
 Tags: AI, Cursor, Chinese, Agentic
 Slug: cursor-ai-entry
+Summary: 在做完[上篇文章](/cursor-to-devin.html)介绍的Cursor魔改之后，将Agentic AI用"我说你做"的模式进行使用，已经成为了我对AI利用的主要方式。而这又进一步启发我：有没有可能把Cursor或者类似的编辑器作为使用AI的通用入口呢？
+
+---
+
+本文是《理解和部署Agentic AI》系列的一部分：
+
+* [Agentic AI系列1：Devin和Agent Cursor使用体验对比](/devin-vs-agent-cursor.html)
+* [Agentic AI系列2：从智者到行者——Agentic AI的范式革命与技术架构](/agentic-ai.html)
+* [Agentic AI系列3：搏一搏，&#36;20变&#36;500：一小时魔改Cursor变身Devin](/cursor-to-devin.html)
+* Agentic AI系列4：使用Cursor作为AI的通用入口（本文）
+
+---
 
 在做完[上篇文章](/cursor-to-devin.html)介绍的Cursor魔改之后，将Agentic AI用"我说你做"的模式进行使用，已经成为了我对AI利用的主要方式。
 而这又进一步启发我：有没有可能把Cursor或者类似的编辑器作为使用AI的通用入口呢？

--- a/content/cursor-to-devin-en.md
+++ b/content/cursor-to-devin-en.md
@@ -1,10 +1,22 @@
-Title: Turning $20 into $500 - Transforming Cursor into Devin in One Hour
+Title: [Agentic AI] Turning $20 into $500 - Transforming Cursor into Devin in One Hour
 Date: 2024-12-17 10:00
 Category: Computing
-Tags: AI, Agentic, English, Cursor
+Tags: AI, Agentic AI, English, Cursor
 Slug: cursor-to-devin-en
+Summary: In the [previous article](/devin-vs-agent-cursor-en.html), we discussed Devin, an Agentic AI capable of fully automated programming. Compared to other Agentic AI tools like Cursor and Windsurf, it has several core advantages, particularly in process planning, self-evolution, expanded tool usage, and fully automated operation. This makes Devin appear to be a next-generation tool, setting itself apart from existing Agentic AI tools.
 
-In the [previous article](https://yage.ai/devin-vs-agent-cursor-en.html), we discussed Devin, an Agentic AI capable of fully automated programming. Compared to other Agentic AI tools like Cursor and Windsurf, it has several core advantages, particularly in process planning, self-evolution, expanded tool usage, and fully automated operation. This makes Devin appear to be a next-generation tool, setting itself apart from existing Agentic AI tools.
+---
+
+This article is part of the "Understanding and Deploying Agentic AI" series:
+
+* [Agentic AI Series 1: Comparison between Devin and Agent Cursor](/devin-vs-agent-cursor-en.html)
+* [Agentic AI Series 2: From Thinker to Doer — The Paradigm Revolution and Technical Architecture of Agentic AI](/agentic-ai-en.html)
+* Agentic AI Series 3: Turning &#36;20 into &#36;500 - Transforming Cursor into Devin in One Hour (This Article)
+* [Agentic AI Series 4: Using Cursor as a Universal Entry Point for AI](/cursor-ai-entry-en.html)
+
+---
+
+In the [previous article](/devin-vs-agent-cursor-en.html), we discussed Devin, an Agentic AI capable of fully automated programming. Compared to other Agentic AI tools like Cursor and Windsurf, it has several core advantages, particularly in process planning, self-evolution, expanded tool usage, and fully automated operation. This makes Devin appear to be a next-generation tool, setting itself apart from existing Agentic AI tools.
 
 However, after using it for a while, my Builder's Mindset started stirring again, driving me to modify Windsurf and Cursor to achieve 90% of Devin's functionality. I've also open-sourced these modifications, allowing you to transform Cursor or Windsurf into Devin in just one minute. This article mainly introduces the specific approach to these modifications, using this example to demonstrate how efficient both building and expanding can be in the Agentic AI era. For simplicity in our discussion, we'll use Cursor to refer to this type of tool, and at the end, we'll discuss what minor adjustments would be needed if you want to use Windsurf instead.
 

--- a/content/cursor-to-devin.md
+++ b/content/cursor-to-devin.md
@@ -1,8 +1,20 @@
-Title: 搏一搏，$20变$500：一小时魔改Cursor变身Devin
+Title: [Agentic AI] 搏一搏，$20变$500：一小时魔改Cursor变身Devin
 Date: 2024-12-17 11:00
 Category: Computing
-Tags: AI, Agentic, Chinese, Cursor
+Tags: AI, Agentic AI, Chinese, Cursor
 Slug: cursor-to-devin
+Summary: 在[上一篇文章](/devin-vs-agent-cursor.html)中，我们提到了Devin这种可以全自动进行编程的Agentic AI。相比于其他Agentic AI工具，比如Cursor和Windsurf，它有几个核心优势，尤其是流程规划、自我进化、更多的工具使用和全自动的工作方式。这让Devin显得是一个下一代的工具，和现有的Agentic AI工具拉开了一个身位。但是在用了它一段时间之后，我的Builder's Mindset又开始蠢蠢欲动，驱使我魔改了Windsurf和Cursor，让它们也能实现Devin 90%的功能。
+
+---
+
+本文是《理解和部署Agentic AI》系列的一部分：
+
+* [Agentic AI系列1：Devin和Agent Cursor使用体验对比](/devin-vs-agent-cursor.html)
+* [Agentic AI系列2：从智者到行者——Agentic AI的范式革命与技术架构](/agentic-ai.html)
+* Agentic AI系列3：搏一搏，&#36;20变&#36;500：一小时魔改Cursor变身Devin（本文）
+* [Agentic AI系列4：使用Cursor作为AI的通用入口](/cursor-ai-entry.html)
+
+---
 
 在[上一篇文章](https://yage.ai/devin-vs-agent-cursor.html)中，我们提到了Devin这种可以全自动进行编程的Agentic AI。相比于其他Agentic AI工具，比如Cursor和Windsurf，它有几个核心优势，尤其是流程规划、自我进化、更多的工具使用和全自动的工作方式。这让Devin显得是一个下一代的工具，和现有的Agentic AI工具拉开了一个身位。
 

--- a/content/devin-agent-cursor-en.md
+++ b/content/devin-agent-cursor-en.md
@@ -1,8 +1,20 @@
-Title: Comparison between Devin and Agent Cursor
+Title: [Agentic AI] Comparison between Devin and Agent Cursor
 Date: 2024-12-12 08:00
 Category: Computing
 Tags: English, AI, Programming, Cursor
 Slug: devin-vs-agent-cursor-en
+Summary: I recently subscribed to Devin, an AI programming tool, for $500 per month. It claims to be a versatile intern capable of performing many tasks that traditional AI tools like Cursor and Windsurf cannot handle. After using it for a while, I noticed significant differences between Devin and Cursor in terms of design philosophy and user experience, which I'll summarize in this article.
+
+---
+
+This article is part of the "Understanding and Deploying Agentic AI" series:
+
+* Agentic AI Series 1: Comparison between Devin and Agent Cursor (This Article)
+* [Agentic AI Series 2: From Thinker to Doer — The Paradigm Revolution and Technical Architecture of Agentic AI](/agentic-ai-en.html)
+* [Agentic AI Series 3: Turning &#36;20 into &#36;500 - Transforming Cursor into Devin in One Hour](/cursor-to-devin-en.html)
+* [Agentic AI Series 4: Using Cursor as a Universal Entry Point for AI](/cursor-ai-entry-en.html)
+
+---
 
 I recently subscribed to Devin, an AI programming tool, for $500 per month.
 It claims to be a versatile intern capable of performing many tasks that traditional AI tools like Cursor and Windsurf cannot handle.

--- a/content/devin-agent-cursor.md
+++ b/content/devin-agent-cursor.md
@@ -1,8 +1,20 @@
-Title: Devin和Agent Cursor使用体验对比
+Title: [Agentic AI] Devin和Agent Cursor使用体验对比
 Date: 2024-12-12 09:00
 Category: Computing
-Tags: Chinese, AI, Programming, Cursor
+Tags: Chinese, AI, Programming, Cursor, Agentic
 Slug: devin-vs-agent-cursor
+Summary: 最近我充了500美元一个月的AI编程工具Devin。他号称是一个全能的实习生，可以做很多传统的AI工具，比如Cursor和Windsurf之类做不了的事情。在使用了一段时间之后，我确实感到了他和Cursor在设计理念和使用体验上有着巨大的不同，在这篇文章里面总结一下。
+
+---
+
+本文是《理解和部署Agentic AI》系列的一部分：
+
+* Agentic AI系列1：Devin和Agent Cursor使用体验对比（本文）
+* [Agentic AI系列2：从智者到行者——Agentic AI的范式革命与技术架构](/agentic-ai.html)
+* [Agentic AI系列3：搏一搏，&#36;20变&#36;500：一小时魔改Cursor变身Devin](/cursor-to-devin.html)
+* [Agentic AI系列4：使用Cursor作为AI的通用入口](/cursor-ai-entry.html)
+
+---
 
 最近我充了500美元一个月的AI编程工具Devin。
 他号称是一个全能的实习生，可以做很多传统的AI工具，比如Cursor和Windsurf之类做不了的事情。


### PR DESCRIPTION
This PR adds Summary field to all articles in the Agentic AI series, both Chinese and English versions.\n\nChanges made:\n- Added Summary field to 4 Chinese articles and 4 English articles\n- Each Summary contains the first substantive paragraph from the article's main content\n- Maintained links and formatting in the summaries where appropriate\n\nThe Summary field helps readers quickly understand the main point of each article before diving in.