### PR TITLE
nav: rename Subscribe→RSS, replace Services with News (/share)

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -40,8 +40,8 @@ EXTRA_PATH_METADATA = {
     'extra/llms.txt': {'path': 'llms.txt'},
 }
 MENUITEMS = (('Archives', '/archives.html'),
-        ('Subscribe', '/pages/feed.html'),
-        ('Services', '/pages/services.html'),
+        ('RSS', '/pages/feed.html'),
+        ('News', '/share/'),
         #('Lab', 'http://lab.grapeot.me/'),)
         ('Duck Sky Survey', 'dssv2/'),
         ('🔍Search', '/search/'),


### PR DESCRIPTION
## Summary
- Renamed "Subscribe" to "RSS" (same target `/pages/feed.html`)
- Replaced "Services" with "News" pointing to `/share/` (AI-generated research reports)
- Services page file (`02services.md`) preserved in case it's linked from elsewhere

## New navigation order
Archives → RSS → News → Duck Sky Survey → 🔍Search