### PR TITLE
Update Duck Sky Survey nav link to dssv2 URL

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -43,7 +43,7 @@ MENUITEMS = (('Archives', '/archives.html'),
         ('Subscribe', '/pages/feed.html'),
         ('Services', '/pages/services.html'),
         #('Lab', 'http://lab.grapeot.me/'),)
-        ('Duck Sky Survey', 'dssv2/'),
+        ('Duck Sky Survey', 'https://yage.ai/dssv2/'),
         ('🔍Search', '/search/'),
         )
 THEME = './themes/gum'


### PR DESCRIPTION
## Summary
- switch the Duck Sky Survey menu item to the canonical absolute URL
- keep the change isolated to pelicanconf.py so the generated site rebuild picks it up on publish

## Verification
- source .venv/bin/activate && make html && pytest tests/ -v