### PR TITLE
Fix SEO meta description escaping

### DIFF
--- a/tests/test_summary_coverage.py
+++ b/tests/test_summary_coverage.py
@@ -1,9 +1,24 @@
-"""Test that all blog articles have Summary metadata for SEO."""
+"""Test that all blog articles have valid Summary metadata for SEO."""
+from html.parser import HTMLParser
+import re
 import pytest
 from pathlib import Path
 
 
 CONTENT_DIR = Path(__file__).parent.parent / "content"
+OUTPUT_DIR = Path(__file__).parent.parent / "output"
+
+
+class MetaParser(HTMLParser):
+    """Collect meta tag attributes from generated article HTML."""
+
+    def __init__(self):
+        super().__init__()
+        self.meta = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "meta":
+            self.meta.append(dict(attrs))
 
 
 def get_all_articles():
@@ -15,6 +30,32 @@ def has_summary(filepath: Path) -> bool:
     """Check if article has Summary field in front matter."""
     content = filepath.read_text(encoding="utf-8")
     return "Summary:" in content
+
+
+def get_frontmatter_field(filepath: Path, field: str) -> str | None:
+    """Read a single-line field from Markdown front matter."""
+    prefix = f"{field}:"
+    for line in filepath.read_text(encoding="utf-8").splitlines():
+        if line.startswith(prefix):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def get_meta_content(html_path: Path, *, name: str | None = None, property_: str | None = None) -> str | None:
+    parser = MetaParser()
+    parser.feed(html_path.read_text(encoding="utf-8"))
+    for meta in parser.meta:
+        if name and meta.get("name") == name:
+            return meta.get("content")
+        if property_ and meta.get("property") == property_:
+            return meta.get("content")
+    return None
+
+
+def normalize_summary_for_meta(summary: str) -> str:
+    """Approximate Pelican's metadata rendering before template striptags."""
+    summary = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", summary)
+    return summary.replace(r"\[", "[").replace(r"\]", "]")
 
 
 class TestSummaryCoverage:
@@ -52,6 +93,36 @@ class TestSummaryCoverage:
             f"The following articles have empty Summary:\n"
             + "\n".join(empty_summaries)
         )
+
+    def test_summary_meta_tags_preserve_full_text(self):
+        """Generated SEO meta tags must preserve Summary without quote truncation."""
+        failures = []
+
+        for article in get_all_articles():
+            slug = get_frontmatter_field(article, "Slug")
+            summary = get_frontmatter_field(article, "Summary")
+            if not slug or not summary:
+                continue
+
+            html_path = OUTPUT_DIR / f"{slug}.html"
+            if not html_path.exists():
+                failures.append(f"{article.name}: missing generated HTML for slug {slug}")
+                continue
+
+            checks = {
+                "description": get_meta_content(html_path, name="description"),
+                "og:description": get_meta_content(html_path, property_="og:description"),
+                "twitter:description": get_meta_content(html_path, name="twitter:description"),
+            }
+
+            expected = normalize_summary_for_meta(summary)
+            for meta_name, actual in checks.items():
+                if actual != expected:
+                    failures.append(
+                        f"{article.name} {meta_name}: expected {expected!r}, got {actual!r}"
+                    )
+
+        assert not failures, "SEO meta description mismatch:\n" + "\n".join(failures)
 
 
 if __name__ == "__main__":

--- a/themes/gum/templates/article.html
+++ b/themes/gum/templates/article.html
@@ -5,7 +5,7 @@
 
 <!-- SEO Meta Tags -->
 {% if article.summary %}
-<meta name="description" content="{{ article.summary|striptags|truncate(160) }}">
+<meta name="description" content="{{ article.summary|striptags|e }}">
 {% endif %}
 
 <!-- Canonical URL -->
@@ -25,7 +25,7 @@
 <meta property="og:title" content="{{ article.title|striptags }}">
 <meta property="og:url" content="{{ SITEURL }}/{{ article.url }}">
 {% if article.summary %}
-<meta property="og:description" content="{{ article.summary|striptags|truncate(200) }}">
+<meta property="og:description" content="{{ article.summary|striptags|e }}">
 {% endif %}
 <meta property="og:site_name" content="{{ SITENAME }}">
 <meta property="og:locale" content="{{ DEFAULT_LANG|replace('_', '-') }}">
@@ -46,7 +46,7 @@
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="{{ article.title|striptags }}">
 {% if article.summary %}
-<meta name="twitter:description" content="{{ article.summary|striptags|truncate(200) }}">
+<meta name="twitter:description" content="{{ article.summary|striptags|e }}">
 {% endif %}
 {% if article.og_image %}
 <meta name="twitter:image" content="{{ SITEURL }}/{{ article.og_image }}">
@@ -60,7 +60,7 @@
   "headline": {{ article.title|striptags|tojson }},
   "url": "{{ SITEURL }}/{{ article.url }}",
   {% if article.summary %}
-  "description": {{ article.summary|striptags|truncate(160)|tojson }},
+  "description": {{ article.summary|striptags|tojson }},
   {% endif %}
   {% if article.date %}
   "datePublished": "{{ article.date.isoformat() }}",


### PR DESCRIPTION
## Summary
- Escape article summaries before writing SEO, Open Graph, and Twitter description meta tags.
- Stop truncating hand-written Summary metadata in article templates.
- Add a regression test that checks generated article meta descriptions preserve the full summary text across all posts.

## Testing
- `source .venv/bin/activate && make test`